### PR TITLE
Calculate the correct auth token expiry time

### DIFF
--- a/src/saic_ismart_client_ng/api/base.py
+++ b/src/saic_ismart_client_ng/api/base.py
@@ -57,7 +57,7 @@ class AbstractSaicApi(ABC):
         )
         # Update the user token
         self.__api_client.user_token = result.access_token
-        self.__token_expiration = datetime.datetime.now() + datetime.timedelta(seconds=result.expires_in)
+        self.__token_expiration = datetime.datetime.now() + datetime.timedelta(milliseconds=result.expires_in)
         return result
 
     async def execute_api_call(


### PR DESCRIPTION
The authentication token's validity is measured in milliseconds, not seconds. This can be fairly easily verified by storing the token and trying to use it the next day; a 401 will be returned.