### PR TITLE
Add public close() to release the HTTP client

### DIFF
--- a/src/saic_ismart_client_ng/api/base.py
+++ b/src/saic_ismart_client_ng/api/base.py
@@ -53,6 +53,10 @@ class AbstractSaicApi:
         self.__api_client = SaicApiClient(configuration, listener=listener)
         self.__token_expiration: datetime.datetime | None = None
 
+    async def close(self) -> None:
+        """Close the API client and release its HTTP resources."""
+        await self.__api_client.close()
+
     async def login(self) -> LoginResp:
         headers = {
             "Content-Type": "application/x-www-form-urlencoded",

--- a/src/saic_ismart_client_ng/net/client/__init__.py
+++ b/src/saic_ismart_client_ng/net/client/__init__.py
@@ -38,6 +38,10 @@ class SaicApiClient:
     async def send(self, request: Request) -> Response:
         return await self.__client.send(request)
 
+    async def close(self) -> None:
+        """Close the underlying HTTP client and release its connections."""
+        await self.__client.aclose()
+
     @property
     def user_token(self) -> str:
         return self.__user_token


### PR DESCRIPTION
Closes #28.

`SaicApiClient` owns an `httpx.AsyncClient` that previously had no public
means of being closed, so consumers couldn't release the transport after
use or after a failed login — it leaked until GC/process exit. This adds:

- `SaicApiClient.close()` — calls `aclose()` on the underlying
  `httpx.AsyncClient`.
- `AbstractSaicApi.close()` — delegates to the client's `close()`.

The change is additive and backward-compatible; no existing behaviour is
altered. Verified that after `await api.close()` the underlying client's
`is_closed` is `True`.

Downstream context: the mg-saic-ha Home Assistant integration currently
reaches the private httpx client to close it as a workaround; once this
ships, it can use the public method instead.